### PR TITLE
Moved session ownership responsibility to a SessionController shared instance.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Xcode
+.DS_Store
+xcuserdata
+
+# CocoaPods
+*.xcworkspace
+Pods

--- a/Testomemex.xcodeproj/project.pbxproj
+++ b/Testomemex.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0A2DA1D41B93B956007FA4E1 /* SessionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A2DA1D31B93B956007FA4E1 /* SessionController.swift */; };
 		B02D6B821B90F49500E90147 /* AddAlertDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B02D6B811B90F49500E90147 /* AddAlertDelegate.swift */; };
 		B0C186731B90B836008E879F /* Thread.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0C186721B90B836008E879F /* Thread.swift */; };
 		B0C186751B90B91D008E879F /* ThreadsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0C186741B90B91D008E879F /* ThreadsTests.swift */; };
@@ -37,6 +38,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0A2DA1D31B93B956007FA4E1 /* SessionController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionController.swift; sourceTree = "<group>"; };
 		B02D6B811B90F49500E90147 /* AddAlertDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddAlertDelegate.swift; sourceTree = "<group>"; };
 		B0C186721B90B836008E879F /* Thread.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Thread.swift; sourceTree = "<group>"; };
 		B0C186741B90B91D008E879F /* ThreadsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThreadsTests.swift; sourceTree = "<group>"; };
@@ -108,6 +110,7 @@
 				B0C186721B90B836008E879F /* Thread.swift */,
 				B02D6B811B90F49500E90147 /* AddAlertDelegate.swift */,
 				B0C1867B1B93878B008E879F /* Session.swift */,
+				0A2DA1D31B93B956007FA4E1 /* SessionController.swift */,
 			);
 			path = Testomemex;
 			sourceTree = "<group>";
@@ -240,6 +243,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B0CEFEA61B8CC34E009FD430 /* DetailViewController.swift in Sources */,
+				0A2DA1D41B93B956007FA4E1 /* SessionController.swift in Sources */,
 				B0C186731B90B836008E879F /* Thread.swift in Sources */,
 				B0CEFEA41B8CC34E009FD430 /* MasterViewController.swift in Sources */,
 				B0CEFEC41B8CC393009FD430 /* Person.swift in Sources */,

--- a/Testomemex/AppDelegate.swift
+++ b/Testomemex/AppDelegate.swift
@@ -12,8 +12,6 @@ import UIKit
 class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDelegate {
 
     var window: UIWindow?
-    var session:Session! = Session(user: Person(id: 1, name:"Mason")) //TODO: Get rid of this default and have a login page!
-    var token:String!
 
     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
         // Override point for customization after application launch.

--- a/Testomemex/MasterViewController.swift
+++ b/Testomemex/MasterViewController.swift
@@ -12,7 +12,9 @@ class MasterViewController: UITableViewController {
 
     var detailViewController: DetailViewController? = nil
     var people:[Person] = []
-    var session:Session!
+
+    // A local copy of the session. SessionController is the authority.
+    var session = SessionController.sharedController.session
 
     override func awakeFromNib() {
         super.awakeFromNib()
@@ -23,8 +25,6 @@ class MasterViewController: UITableViewController {
     }
 
     override func viewDidLoad() {
-        let app = UIApplication.sharedApplication().delegate as! AppDelegate
-        self.session = app.session
         super.viewDidLoad()
         // Do any additional setup after loading the view, typically from a nib.
         self.navigationItem.leftBarButtonItem = self.editButtonItem()

--- a/Testomemex/Session.swift
+++ b/Testomemex/Session.swift
@@ -8,14 +8,14 @@
 
 import Foundation
 
-class Session {
-    var user:Person
+struct Session {
+    let user:Person
     var token:String?
     
     init(user:Person) {
         self.user = user
     }
-    
+
     func getToken() {
         // TODO: hit API with email and password
         // Store token returned by api

--- a/Testomemex/SessionController.swift
+++ b/Testomemex/SessionController.swift
@@ -1,0 +1,34 @@
+//
+//  SessionController.swift
+//  Testomemex
+//
+//  Created by Kevin Conner on 8/30/15.
+//  Copyright (c) 2015 Mason F. Matthews. All rights reserved.
+//
+
+import UIKit
+
+// A session controller owns the session model.
+// View controllers can use the shared instance to get the current session.
+
+final class SessionController {
+
+    // Register for this notification to be notified when the session changes.
+    static let sessionDidChangeNotification = "SessionControllerSessionDidChange"
+
+    var session: Session {
+        didSet {
+            // When the session changes, notify anyone who uses this data.
+            let notification = NSNotification(name: SessionController.sessionDidChangeNotification, object: self)
+            NSNotificationCenter.defaultCenter().postNotification(notification)
+        }
+    }
+
+    static let sharedController = SessionController()
+
+    private init() {
+        //TODO: Get rid of this default and have a login page!
+        session = Session(user: Person(id: 1, name:"Mason"))
+    }
+
+}


### PR DESCRIPTION
- `AppDelegate` does not own any data.
- `SessionController` is the authority on what the session is, and it stands alone.
- `Session` is a struct (a value type), meaning `MasterViewController` keeps a *copy* of the session, not a reference to the same instance. So when the session changes, `MasterViewController` doesn't have its model undermined until it's ready. Structs are often appropriate for model types.
- `Session.user` is a constant. By default, use `let` and not `var` until you decide a property or local needs to be variable.
- `SessionController` posts a notification when the session changes, so MasterViewController and any other interested parties can update. I did not write any code to observe that notification, since responding to session changes seemed beyond the scope of what you've built thus far.
- I added a starter .gitignore for Xcode / iOS projects.